### PR TITLE
Turbolinks cache control

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   include Pundit
+  include TurbolinksCacheControl
 
   # Pundit: white-list approach.
   after_action :verify_authorized, except: :index, unless: :skip_pundit?

--- a/app/controllers/concerns/turbolinks_cache_control.rb
+++ b/app/controllers/concerns/turbolinks_cache_control.rb
@@ -1,0 +1,21 @@
+module TurbolinksCacheControl
+  # extend ActiveSupport::Concern
+
+  # included do
+  #   before_action :disable_turbolinks_preview_cache, only: %i[new edit]
+  # end
+
+  private
+
+  def enable_turbolinks_cache
+    @turbolinks_cache_control = 'cache'
+  end
+
+  def disable_turbolinks_cache
+    @turbolinks_cache_control = 'no-cache'
+  end
+
+  def disable_turbolinks_preview_cache
+    @turbolinks_cache_control = 'no-preview'
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,6 +2,7 @@ class DocumentsController < ApplicationController
   include ListHelper
 
   before_action :find_document, only: %i[show]
+  before_action :disable_turbolinks_cache, only: %i[index]
 
   def show
     @shared_document = SharedDocument.new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def turbolinks_cache_control_meta_tag
+    tag :meta, name: 'turbolinks-cache-control', content: @turbolinks_cache_control || 'cache'
+  end
 end

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -30,11 +30,4 @@ export default class extends Controller {
     this.formatTarget.value = ""
     this.languageTarget.value = ""
   }
-
-  disconnect() {
-    this.clearSearchValues()
-    if (this.dropdownIconTarget.classList.contains('fa-sort-up')) {
-      this.toggle()
-    }
-  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>GileadMedia</title>
     <%= csrf_meta_tags %>
+    <%= turbolinks_cache_control_meta_tag %>
     <%= csp_meta_tag %>
     <%= favicon_link_tag %>
 


### PR DESCRIPTION
- add turbolinks_cache_control_controller
- add TurbolinksCacheControl in application controller
- add turbolinks_cache_control_meta_tag in application.html.erb
- add def turbolinks_cache_control_meta_tag in application helper
- disable turbolinks cache in documents controller for index
- remove disconnect function in search controller.js as not useful any more