### PR TITLE
Custom mail object and signature

### DIFF
--- a/app/controllers/shared_documents_controller.rb
+++ b/app/controllers/shared_documents_controller.rb
@@ -43,7 +43,7 @@ class SharedDocumentsController < ApplicationController
   end
 
   def shared_document_params
-    params.require(:shared_document).permit(:validity, :download, custom_mail_attributes: [:body])
+    params.require(:shared_document).permit(:validity, :download, custom_mail_attributes: [:subject, :body, :signature])
   end
 
   def contacts_params

--- a/app/controllers/shared_folders_controller.rb
+++ b/app/controllers/shared_folders_controller.rb
@@ -43,7 +43,7 @@ class SharedFoldersController < ApplicationController
   end
 
   def shared_folder_params
-    params.require(:shared_folder).permit(:validity, :download, custom_mail_attributes: [:body])
+    params.require(:shared_folder).permit(:validity, :download, custom_mail_attributes: [:subject, :body, :signature])
   end
 
   def contacts_params

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -48,6 +48,6 @@ class SharedListsController < ApplicationController
   end
 
   def custom_mail_params
-    params.require(:shared_list).permit(custom_mail_attributes: [:body])
+    params.require(:shared_list).permit(custom_mail_attributes: [:subject, :body, :signature])
   end
 end

--- a/app/javascript/controllers/autogrow_text_area_controller.js
+++ b/app/javascript/controllers/autogrow_text_area_controller.js
@@ -4,16 +4,23 @@ export default class extends Controller {
   static targets = [ "area" ]
 
   connect() {
-    // resize body custom-mail input text to fit content
-    const input = this.areaTarget
+    const areass = this.areaTargets
 
-    if (input.offsetHeight != 0) {
-      input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
+    areas.forEach((input) => {
+      this.autogrowTextArea(area)
+    })
+  }
+
+  autogrowTextArea = (area) => {
+    if (area.offsetHeight != 0) {
+      area.style.overflow = "hidden"
+      area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
     }
 
-    input.addEventListener('keyup', (event) => {
-      input.style.height = null
-      input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
+    area.addEventListener('keyup', (event) => {
+      area.style.overflow = "hidden"
+      area.style.height = null
+      area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
     })
   }
 }

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -3,6 +3,6 @@ class ContactMailer < ApplicationMailer
     @contact = contact
     @user = @contact.contactable.user
     @custom_mail = @contact.contactable.custom_mail
-    mail(to: @contact.email, subject: "#{@user.full_name} souhaite partager des documents avec vous")
+    mail(to: @contact.email, subject: "#{@custom_mail.subject}")
   end
 end

--- a/app/models/custom_mail.rb
+++ b/app/models/custom_mail.rb
@@ -3,15 +3,25 @@ class CustomMail < ApplicationRecord
 
   delegate :user, to: :mailable
 
+  validates :subject, presence: true
   validates :body, presence: true
+  validates :signature, presence: true
+
+  def subject_default_value
+    "#{user.full_name} souhaite partager des documents avec vous"
+  end
 
   def body_default_value
-    "Bonjour,\n\n#{sentence}\n\nPour y accéder, veuillez cliquer sur le lien ci dessous:"
+    "Bonjour,\n\n#{body_sentence}\n\nPour y accéder, veuillez cliquer sur le lien ci dessous:"
+  end
+
+  def signature_default_value
+    "Nous vous en souhaitons bonne réception.\n\nBien cordialement,"
   end
 
   private
 
-  def sentence
+  def body_sentence
     case mailable_type
     when "SharedFolder"
       "#{user.full_name} souhaite partager un dossier avec vous."

--- a/app/models/custom_mail.rb
+++ b/app/models/custom_mail.rb
@@ -8,11 +8,11 @@ class CustomMail < ApplicationRecord
   validates :signature, presence: true
 
   def subject_default_value
-    "#{user.full_name} souhaite partager des documents avec vous"
+    general_sentence
   end
 
   def body_default_value
-    "Bonjour,\n\n#{body_sentence}\n\nPour y accéder, veuillez cliquer sur le lien ci dessous:"
+    "Bonjour,\n\n#{general_sentence}.\n\nPour y accéder, veuillez cliquer sur le lien ci dessous:"
   end
 
   def signature_default_value
@@ -21,24 +21,14 @@ class CustomMail < ApplicationRecord
 
   private
 
-  def body_sentence
+  def general_sentence
     case mailable_type
     when "SharedFolder"
-      "#{user.full_name} souhaite partager un dossier avec vous."
+      "#{user.full_name} souhaite partager un dossier avec vous"
     when "SharedDocument"
-      "#{user.full_name} souhaite partager un document avec vous."
+      "#{user.full_name} souhaite partager un document avec vous"
     when "SharedList"
-      "#{user.full_name} souhaite partager des documents avec vous."
+      "#{user.full_name} souhaite partager des documents avec vous"
     end
   end
 end
-
-# <p>Bonjour,</p>
-
-# <% if @contact.contactable_type == "SharedList" %>
-#   <p><%= @user.full_name %> souhaite partager des documents avec vous.</p>
-# <% elsif @contact.contactable_type == "SharedDocument" %>
-#   <p><%= @user.full_name %> souhaite partager un document avec vous.</p>
-# <% elsif @contact.contactable_type == "SharedFolder" %>
-#   <p><%= @user.full_name %> souhaite partager un dossier avec vous.</p>
-# <% end %>

--- a/app/views/contact_mailer/notify_contacts.html.erb
+++ b/app/views/contact_mailer/notify_contacts.html.erb
@@ -15,3 +15,5 @@
     </tr>
   </tbody>
 </table>
+
+<p><%= simple_format(@custom_mail.signature) %></p>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -37,7 +37,6 @@
 
   <body>
     <%= yield %>
-    <p>Nous vous en souhaitons bonne réception.</p>
     <%= image_tag("Logo_GileadMédia_Noir.png", width: '192') %>
   </body>
 </html>

--- a/app/views/shared_documents/_form.slim
+++ b/app/views/shared_documents/_form.slim
@@ -8,8 +8,11 @@
   = f.association :contacts do |c|
     = c.input :email, label: "Destinataires", input_html: { value: shared_document.contacts.map(&:email).join(", ") }
   = render 'contacts/errors_on_association', object: shared_document
+  h5.color-burgundy.text-left.mb-4 E-mail
   .label-input-in-column
     = f.association :custom_mail do |custom_mail|
-      = custom_mail.input :body, label: "Corps du mail", input_html: { value: "#{shared_document.custom_mail.body.blank? && shared_document.errors.messages[:"custom_mail.body"].blank? ? shared_document.custom_mail.body_default_value : shared_document.custom_mail.body}" }
+      = custom_mail.input :subject, input_html: { value: "#{shared_document.custom_mail.subject.blank? && shared_document.errors.messages[:"custom_mail.subject"].blank? ? shared_document.custom_mail.subject_default_value : shared_document.custom_mail.subject}" }
+      = custom_mail.input :body, input_html: { value: "#{shared_document.custom_mail.body.blank? && shared_document.errors.messages[:"custom_mail.body"].blank? ? shared_document.custom_mail.body_default_value : shared_document.custom_mail.body}" }
+      = custom_mail.input :signature, input_html: { value: "#{shared_document.custom_mail.signature.blank? && shared_document.errors.messages[:"custom_mail.signature"].blank? ? shared_document.custom_mail.signature_default_value : shared_document.custom_mail.signature}" }
 
   = f.submit "Envoyer", class: "btn"

--- a/app/views/shared_documents/new.js.erb
+++ b/app/views/shared_documents/new.js.erb
@@ -1,17 +1,26 @@
 $(".modal#addDocumentToSharedDocument .modal-header h5").replaceWith("<h5><%= @document.title %></h5>");
 $("form#new_shared_document").replaceWith("<%= j render('shared_documents/form', document: @document, shared_document: @shared_document) %>");
 
-// resize body custom-mail input text to fit content
-var input = document.getElementById("shared_document_custom_mail_attributes_body")
-if (input.offsetHeight != 0) {
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
+// resize custom-mail inputs text to fit content
+function autogrowTextArea(area) {
+  if (area.offsetHeight != 0) {
+    area.style.overflow = "hidden" // hide sroll bar
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  }
+
+  $(".modal#addFolderToSharedFolder").on('shown.bs.modal', (event) => {
+    area.style.overflow = "hidden"
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  })
+
+  area.addEventListener('keyup', (event) => {
+    area.style.overflow = "hidden"
+    area.style.height = null
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  })
 }
 
-$(".modal#addDocumentToSharedDocument").on('shown.bs.modal', (event) => {
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
-})
-
-input.addEventListener('keyup', (event) => {
-  input.style.height = null
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
-})
+var customMailBodyInput = document.getElementById("shared_document_custom_mail_attributes_body")
+var customMailSignatureInput = document.getElementById("shared_document_custom_mail_attributes_signature")
+autogrowTextArea(customMailBodyInput)
+autogrowTextArea(customMailSignatureInput)

--- a/app/views/shared_folders/_form.slim
+++ b/app/views/shared_folders/_form.slim
@@ -8,8 +8,11 @@
   = f.association :contacts do |c|
     = c.input :email, label: "Destinataires", input_html: { value: shared_folder.contacts.map(&:email).join(", ") }
   = render 'contacts/errors_on_association', object: shared_folder
+  h5.color-burgundy.text-left.mb-4 E-mail
   .label-input-in-column
     = f.association :custom_mail do |custom_mail|
-      = custom_mail.input :body, label: "Corps du mail", input_html: { value: "#{shared_folder.custom_mail.body.blank? && shared_folder.errors.messages[:"custom_mail.body"].blank? ? shared_folder.custom_mail.body_default_value : shared_folder.custom_mail.body}" }
+      = custom_mail.input :subject, input_html: { value: "#{shared_folder.custom_mail.subject.blank? && shared_folder.errors.messages[:"custom_mail.subject"].blank? ? shared_folder.custom_mail.subject_default_value : shared_folder.custom_mail.subject}" }
+      = custom_mail.input :body, input_html: { value: "#{shared_folder.custom_mail.body.blank? && shared_folder.errors.messages[:"custom_mail.body"].blank? ? shared_folder.custom_mail.body_default_value : shared_folder.custom_mail.body}" }
+      = custom_mail.input :signature, input_html: { value: "#{shared_folder.custom_mail.signature.blank? && shared_folder.errors.messages[:"custom_mail.signature"].blank? ? shared_folder.custom_mail.signature_default_value : shared_folder.custom_mail.signature}" }
 
   = f.submit "Envoyer", class: "btn"

--- a/app/views/shared_folders/new.js.erb
+++ b/app/views/shared_folders/new.js.erb
@@ -1,17 +1,27 @@
 $(".modal#addFolderToSharedFolder .modal-header h5").replaceWith("<h5><%= @folder.title %></h5>");
 $("form#new_shared_folder").replaceWith("<%= j render('shared_folders/form', folder: @folder, shared_folder: @shared_folder) %>");
 
-// resize body custom-mail input text to fit content
-var input = document.getElementById("shared_folder_custom_mail_attributes_body")
-if (input.offsetHeight != 0) {
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
+// resize custom-mail inputs text to fit content
+function autogrowTextArea(area) {
+  if (area.offsetHeight != 0) {
+    area.style.overflow = "hidden" // hide sroll bar
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  }
+
+  $(".modal#addFolderToSharedFolder").on('shown.bs.modal', (event) => {
+    area.style.overflow = "hidden"
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  })
+
+  area.addEventListener('keyup', (event) => {
+    area.style.overflow = "hidden"
+    area.style.height = null
+    area.style.height = `${area.scrollHeight + (area.offsetHeight - area.clientHeight)}px`
+  })
 }
 
-$(".modal#addFolderToSharedFolder").on('shown.bs.modal', (event) => {
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
-})
+var customMailBodyInput = document.getElementById("shared_folder_custom_mail_attributes_body")
+var customMailSignatureInput = document.getElementById("shared_folder_custom_mail_attributes_signature")
+autogrowTextArea(customMailBodyInput)
+autogrowTextArea(customMailSignatureInput)
 
-input.addEventListener('keyup', (event) => {
-  input.style.height = null
-  input.style.height = `${input.scrollHeight + (input.offsetHeight - input.clientHeight)}px`
-})

--- a/app/views/shared_lists/_add_contacts_form.slim
+++ b/app/views/shared_lists/_add_contacts_form.slim
@@ -5,8 +5,11 @@
       = c.input :email, label: "Destinataires", required: false, disabled: !shared_list.initial?, input_html: { value: shared_list.contacts.pluck(:email).join(", ") }
     = render 'contacts/errors_on_association', object: shared_list
     div class="#{'d-none' if shared_list.contacts_added?}"
+      h5.color-burgundy.text-left.mb-4 E-mail
       = f.association :custom_mail do |custom_mail|
-        = custom_mail.input :body, label: "Corps du mail", input_html: { value: "#{shared_list.custom_mail.body.blank? && shared_list.errors.messages[:"custom_mail.body"].blank? ? shared_list.custom_mail.body_default_value : shared_list.custom_mail.body}", data: {target: "autogrow-text-area.area"} }
+        = custom_mail.input :subject, input_html: { value: "#{shared_list.custom_mail.subject.blank? && shared_list.errors.messages[:"custom_mail.subject"].blank? ? shared_list.custom_mail.subject_default_value : shared_list.custom_mail.subject}" }
+        = custom_mail.input :body, input_html: { value: "#{shared_list.custom_mail.body.blank? && shared_list.errors.messages[:"custom_mail.body"].blank? ? shared_list.custom_mail.body_default_value : shared_list.custom_mail.body}", data: {target: "autogrow-text-area.area"} }
+        = custom_mail.input :signature, input_html: { value: "#{shared_list.custom_mail.signature.blank? && shared_list.errors.messages[:"custom_mail.signature"].blank? ? shared_list.custom_mail.signature_default_value : shared_list.custom_mail.signature}", data: {target: "autogrow-text-area.area"} }
     - if shared_list.initial?
       .text-right = f.button :submit, "Envoyer", class: "btn", data: {confirm: "<p class='text-center mt-n-3'>Vous êtes sur le point d'envoyer votre liste de partage.<br>Souhaitez-vous confirmer?</p>".html_safe}
 

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -37,7 +37,9 @@ fr:
         validity: Jusqu'au
         download: Téléchargeable
       custom_mail:
-        body: Corps du mail
+        subject: Objet
+        body: Corps
+        signature: Signature
 
     errors:
       models:

--- a/db/migrate/20210318093854_add_subject_and_signature_to_custom_mails.rb
+++ b/db/migrate/20210318093854_add_subject_and_signature_to_custom_mails.rb
@@ -1,0 +1,6 @@
+class AddSubjectAndSignatureToCustomMails < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_mails, :subject, :string
+    add_column :custom_mails, :signature, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_16_090958) do
+ActiveRecord::Schema.define(version: 2021_03_18_093854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,8 @@ ActiveRecord::Schema.define(version: 2021_03_16_090958) do
     t.bigint "mailable_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "subject"
+    t.text "signature"
     t.index ["mailable_type", "mailable_id"], name: "index_custom_mails_on_mailable_type_and_mailable_id"
   end
 


### PR DESCRIPTION
- add subject and signature to custom_mails
- add translations for subject and signature
- remove signature sentence from mailer layout
- display custom_mail subject and signature in mail sent
- add validations in custom_mail model + default subject & signature
- add subject and signature inputs in forms
- add subject and signature in controllers params
- autogrow size of input area for signature