### PR TITLE
disable turbolinks cache on certain actions

### DIFF
--- a/app/controllers/admin/documents_controller.rb
+++ b/app/controllers/admin/documents_controller.rb
@@ -1,6 +1,7 @@
 class Admin::DocumentsController < ApplicationController
   before_action :find_document, only: %i[edit update destroy attach_to_folder]
   before_action :find_document_with_document_id, only: %i[validate]
+  before_action :disable_turbolinks_cache, only: %i[create update]
 
   def validate
     @document.validation_at = DateTime.now

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UsersController < ApplicationController
+  before_action :disable_turbolinks_cache, only: %i[create]
 
   def index
     @users = policy_scope([:admin, User])

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -5,6 +5,7 @@ class FoldersController < ApplicationController
   skip_before_action :authenticate_user!, only: :download
   before_action :find_folder, only: %i[show download add_to_shared_list attach_to_new_shared_list attach_to_existing_shared_list]
   before_action :find_documents, only: %i[show download]
+  before_action :disable_turbolinks_cache, only: %i[index show]
 
   def index
     @folders = policy_scope(Folder)

--- a/app/controllers/shared_lists_controller.rb
+++ b/app/controllers/shared_lists_controller.rb
@@ -1,6 +1,7 @@
 class SharedListsController < ApplicationController
   include ListHelper
   before_action :find_shared_list, only: %i[show add_contacts]
+  before_action :disable_turbolinks_cache, only: %i[show]
 
   def index
     @shared_lists = policy_scope(SharedList)


### PR DESCRIPTION
disable turbolinks cache on certain actions to avoid rendering cache